### PR TITLE
Update PubMedAPI.php

### DIFF
--- a/PubMedAPI.php
+++ b/PubMedAPI.php
@@ -105,7 +105,7 @@ class PubMedAPI
 			'retmode'	=> $this->retmode,
 			'retmax'	=> $this->retmax,
 			'retstart'	=> $this->retstart,
-			'term'		=> stripslashes($term)
+			'term'		=> stripslashes(urlencode($term))
 		);
 		foreach ($params as $key => $value) { $q[] = $key . '=' . $value; }
 		$httpquery = implode('&',$q);


### PR DESCRIPTION
When a query string such as "allergy symptoms for demodex" is passed to the pubmed_esearch() function, only the first word from the query was being used to look up PubMed articles, i.e. "allergy". This was caused because the term was not being properly encoded. I added the urlencode() call to the term.
